### PR TITLE
feat(feijoada-ui): Editor: disposeCanvas

### DIFF
--- a/packages/feijoada-ui/src/pages/EditorCore.js
+++ b/packages/feijoada-ui/src/pages/EditorCore.js
@@ -41,6 +41,13 @@ export default class EditorCore extends React.Component {
       doc: EDITOR_DEFAULT_TEMPLATE,
     };
   }
+  async disposeCanvas() {
+    if (GET_CANVAS()) {
+      const canvas = GET_CANVAS();
+      canvas.dispose();
+      DELETE_CANVAS();
+    }
+  }
   async removeStaticImage(idx) {
     await new Promise((resolve) => {
       this.setState(REMOVE_STATIC_IMAGE({ idx }), resolve);


### PR DESCRIPTION
delete and executes `dispose` method from the editor canvas